### PR TITLE
New features!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,23 @@
 ### GULPFILE ###
 
-This gulpfile has been created to split `app` files from the `admin` ones. It has also an `extra` feature that let's you create the namespace you want without modifing the Gulpfile settings.
+This gulpfile has been created to split `app` files from the `admin` ones. It has also an `extra` feature that let's you create the namespace you want without modifing Gulpfile settings.
 
 It has been thought for Ruby on Rails 4.2.6 or later and Node 6.2.0 or later.
 
 
 ### Required structure ###
 
-In order to work you need to have the following directory structure:
+In order to setup properly copy/paste `gulpfile.js` and `package.json` in your project's root. To install gulp dependencies run the following commands from Terminal (or any command-line):
+```
+  npm install
+```
+
+After that you can setup the assets directory. You can do it manually or using the following command:
+```
+  gulp setup
+```
+
+This will setup the basic structure for your application which is explained here below.
 
 **JAVASCRIPT**
 ```
@@ -37,18 +47,24 @@ In order to work you need to have the following directory structure:
           app.css         -> File to require in App Rails pipeline
 ```
 
-You can use the following commands:
+After your directory is correctly setup you can use the following commands:
 
-* `gulp sass`: preprocesses sass files
-* `gulp js`: preprocesses js files
-* `gulp`: executes `gulp sass` and `gulp js`
-* `gulp watch`: watches stylesheet and javascript directories and executes `gulp sass` and `gulp js` on every file change
-* `gulp bs`: runs Browsersync in background and executes `gulp sass` and `gulp js` on every file change
+* `gulp sass`: it preprocesses sass files
+* `gulp js`: it preprocesses js files
+* `gulp`: it executes `gulp sass` and `gulp js`
+* `gulp watch`: it watches stylesheet and javascript directories and executes `gulp sass` and `gulp js` on every file change
+* `gulp bs`: it runs Browsersync in background and executes `gulp sass` and `gulp js` on every file change
 
 
 ### Admin files ###
 
-If you want to keep your admin files separated you can create the same structure as before but within `admin` namespace. Refer to the following schema.
+If you want to keep your admin files separated you can create the same structure as before but within `admin` namespace. 
+To automagically setup the file you need run:
+```
+  gulp setup --admin
+```
+
+This will setup the directory as listed here below.
 
 **JAVASCRIPT**
 ```
@@ -80,27 +96,27 @@ If you want to keep your admin files separated you can create the same structure
 
 In order to refer to `admin` namespace just add `--admin` at the end of the gulp command. 
 
-* `gulp sass --admin`: preprocesses sass files
-* `gulp js --admin`: preprocesses js files
-* `gulp --admin`: executes `gulp sass --admin` and `gulp js --admin`
-* `gulp watch --admin`: watches stylesheet and javascript directories and executes `gulp sass --admin` and `gulp js --admin` on every file change
-* `gulp bs --admin`: runs Browsersync in background and executes `gulp sass --admin` and `gulp js --admin` on every file change
+* `gulp sass --admin`: it preprocesses sass files
+* `gulp js --admin`: it preprocesses js files
+* `gulp --admin`: it executes `gulp sass --admin` and `gulp js --admin`
+* `gulp watch --admin`: it watches stylesheet and javascript directories and executes `gulp sass --admin` and `gulp js --admin` on every file change
+* `gulp bs --admin`: it runs Browsersync in background and executes `gulp sass --admin` and `gulp js --admin` on every file change
 
 
 ### Extra feature ###
 
 Always wanted to `gulp watch --extra myPlugin`?
 
-You might want to have third namespace for a plugin that you use only on one specific view of your app. For example a script called `myPlugin` (it can be anything you want). The only thing you have to do is create the structure for it as you have done for admin and replacing admin with `myPlugin`. Then you'll be able to execute gulp commands using appendin `--extra myPlugin` to them. 
+You might want to have third namespace for a plugin that you use only on one specific view of your app. For example a script called `myPlugin` (it can be anything you want). The only thing you have to do is create the structure for it as you have done before with the setup task:
+```
+  gulp setup --extra myPlugin
+```
 
-* `gulp sass --extra myPlugin`: preprocesses sass files
-* `gulp js --extra myPlugin`: preprocesses js files
-* `gulp --extra myPlugin`: executes `gulp sass --extra myPlugin` and `gulp js --extra myPlugin`
-* `gulp watch --extra myPlugin`: watches stylesheet and javascript directories and executes `gulp sass --extra myPlugin` and `gulp js --extra myPlugin` on every file change
-* `gulp bs --extra myPlugin`: runs Browsersync in background and executes `gulp sass --extra myPlugin` and `gulp js --extra myPlugin` on every file change
+Then you'll be able to execute gulp commands using appendin `--extra myPlugin` to them.
 
+* `gulp sass --extra myPlugin`: it preprocesses sass files
+* `gulp js --extra myPlugin`: it preprocesses js files
+* `gulp --extra myPlugin`: it executes `gulp sass --extra myPlugin` and `gulp js --extra myPlugin`
+* `gulp watch --extra myPlugin`: it watches stylesheet and javascript directories and executes `gulp sass --extra myPlugin` and `gulp js --extra myPlugin` on every file change
+* `gulp bs --extra myPlugin`: it runs Browsersync in background and executes `gulp sass --extra myPlugin` and `gulp js --extra myPlugin` on every file change
 
-----
-
-### NEXT FEATURES ###
-* Implement a command to create the structure automagically

--- a/README.md
+++ b/README.md
@@ -1,2 +1,86 @@
-# gulpfile
-gulpfile
+### GULPFILE ###
+
+This gulpfile has been created to split `app` files from the `admin` ones. It has also an `extra` feature that let's you create the namespace you want without modifing the Gulpfile settings.
+
+It has been thought for Ruby on Rails 4.2.6 or later and Node 6.2.0 or later.
+
+# Required structure #
+
+In order to work you need to have the following directory structure:
+
+**JAVASCRIPT**
+```
+  app/
+    assets/
+      javascripts/
+
+        application.js    -> Rails pipeline referral
+        app/              -> Put here any App js file
+          app.js          -> Gulp (browserify) referral
+
+        dist/
+          app.bundle.js   -> File to require in App Rails pipeline
+```
+
+**STYLESHEETS**
+```
+  app/
+    assets/
+      stylesheets/
+
+        application.css   -> Rails pipeline referral
+        app/              -> Put here any App css file
+          app.scss        -> Gulp referral
+
+        dist/
+          app.css         -> File to require in App Rails pipeline
+```
+
+You can use the following commands:
+
+* `gulp sass`: preprocesses sass files
+* `gulp js`: preprocesses js files
+* `gulp`: executes `gulp sass` and `gulp js`
+* `gulp watch`: watches stylesheet and javascript directories and executes `gulp sass` and `gulp js` on every file change
+* `gulp bs`: runs Browsersync in background and executes `gulp sass` and `gulp js` on every file change
+
+# Admin files #
+
+If you want to keep your admin files separated you can create the same structure as before but within `admin` namespace. Refer to the following schema.
+
+**JAVASCRIPT**
+```
+  app/
+    assets/
+      javascripts/
+
+        admin.js          -> Rails pipeline referral
+        admin/            -> Put here any Admin js file
+          admin.js        -> Gulp (browserify) referral
+
+        dist/
+          admin.bundle.js -> File to require in Admin Rails pipeline
+```
+
+**STYLESHEETS**
+```
+  app/
+    assets/
+      stylesheets/
+
+        admin.css         -> Rails pipeline referral
+        admin/            -> Put here any Admin css file
+          admin.scss      -> Gulp referral
+
+        dist/
+          admin.css       -> File to require in Admin Rails pipeline
+```
+
+In order to refer to `admin` namespace just add `--admin` at the end of the gulp command. For example `gulp watch --admin` or  simply `gulp --admin`.
+
+# Extra feature #
+
+You might want to have third namespace for a plugin that you use only on one specific view of your app. For example a script called `myPlugin`. The only thing you have to do is create the structure for it as you have done for admin and replacing admin with `myPlugin`. Then you'll be able to execute gulp commands using appendin `--extra myPlugin` to them. For example `gulp watch --extra myPlugin` or `gulp --extra myPlugin`.
+
+# NEXT FEATURES #
+* Implement a command to create the structure automagically

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ The idea behind this is to split your `app` files from the `admin` ones. It has 
 It has been thought for Ruby on Rails 4.2.6 or later and Node 6.2.0 or later.
 
 What you can do:
-* Use gulp for your [application assets][app]
-* Use gulp for your [admin assets][admin]
-* Use gulp for your [plugin assets][extra]
+* Use gulp for your [application assets](app)
+* Use gulp for your [admin assets](admin)
+* Use gulp for your [plugin assets](extra)
 
 * * * 
 
-### [app]Required structure ###
+<a name='app'></a>
+### Required structure ###
 
 In order to setup properly copy/paste `gulpfile.js` and `package.json` in your project's root. To install gulp dependencies run the following commands from Terminal (or any command-line):
 ```
@@ -64,8 +65,8 @@ After your directory is correctly setup you can use the following commands:
 * `gulp bs`: it runs Browsersync in background and executes `gulp sass` and `gulp js` on every file change
 
 * * *
-
-###[admin] Admin files ###
+<a name='admin'></a>
+### Admin files ###
 
 If you want to keep your admin files separated you can create the same structure as before but within `admin` namespace. 
 To automagically setup the file you need run:
@@ -112,8 +113,8 @@ In order to refer to `admin` namespace just add `--admin` at the end of the gulp
 * `gulp bs --admin`: it runs Browsersync in background and executes `gulp sass --admin` and `gulp js --admin` on every file change
 
 * * *
-
-###[extra] Extra feature ###
+<a name='extra'></a>
+### Extra feature ###
 
 Always wanted to `gulp watch --extra myPlugin`?
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ What you can do:
 * Use gulp for your [plugin assets][extra]
 
 * * * 
-[app]
-### Required structure ###
+
+###[app] Required structure ###
 
 In order to setup properly copy/paste `gulpfile.js` and `package.json` in your project's root. To install gulp dependencies run the following commands from Terminal (or any command-line):
 ```
@@ -64,8 +64,8 @@ After your directory is correctly setup you can use the following commands:
 * `gulp bs`: it runs Browsersync in background and executes `gulp sass` and `gulp js` on every file change
 
 * * *
-[admin]
-### Admin files ###
+
+###[admin] Admin files ###
 
 If you want to keep your admin files separated you can create the same structure as before but within `admin` namespace. 
 To automagically setup the file you need run:
@@ -113,8 +113,8 @@ In order to refer to `admin` namespace just add `--admin` at the end of the gulp
 
 * * *
 
-### Extra feature ###
-[extra]
+###[extra] Extra feature ###
+
 Always wanted to `gulp watch --extra myPlugin`?
 
 You might want to have third namespace for a plugin that you use only on one specific view of your app. For example a script called `myPlugin` (it can be anything you want). The only thing you have to do is create the structure for it as you have done before with the setup task:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ The idea behind this is to split your `app` files from the `admin` ones. It has 
 It has been thought for Ruby on Rails 4.2.6 or later and Node 6.2.0 or later.
 
 What you can do:
-* Use gulp for your [application assets](app)
-* Use gulp for your [admin assets](admin)
-* Use gulp for your [plugin assets](extra)
+* Use gulp for your [application assets](#app)
+* Use gulp for your [admin assets](#admin)
+* Use gulp for your [plugin assets](#extra)
 
 * * * 
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This gulpfile has been created to split `app` files from the `admin` ones. It ha
 
 It has been thought for Ruby on Rails 4.2.6 or later and Node 6.2.0 or later.
 
+* * * 
 
 ### Required structure ###
 
@@ -55,6 +56,7 @@ After your directory is correctly setup you can use the following commands:
 * `gulp watch`: it watches stylesheet and javascript directories and executes `gulp sass` and `gulp js` on every file change
 * `gulp bs`: it runs Browsersync in background and executes `gulp sass` and `gulp js` on every file change
 
+* * *
 
 ### Admin files ###
 
@@ -102,6 +104,7 @@ In order to refer to `admin` namespace just add `--admin` at the end of the gulp
 * `gulp watch --admin`: it watches stylesheet and javascript directories and executes `gulp sass --admin` and `gulp js --admin` on every file change
 * `gulp bs --admin`: it runs Browsersync in background and executes `gulp sass --admin` and `gulp js --admin` on every file change
 
+* * *
 
 ### Extra feature ###
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This gulpfile has been created to split `app` files from the `admin` ones. It ha
 
 It has been thought for Ruby on Rails 4.2.6 or later and Node 6.2.0 or later.
 
+
 ### Required structure ###
 
 In order to work you need to have the following directory structure:
@@ -44,6 +45,7 @@ You can use the following commands:
 * `gulp watch`: watches stylesheet and javascript directories and executes `gulp sass` and `gulp js` on every file change
 * `gulp bs`: runs Browsersync in background and executes `gulp sass` and `gulp js` on every file change
 
+
 ### Admin files ###
 
 If you want to keep your admin files separated you can create the same structure as before but within `admin` namespace. Refer to the following schema.
@@ -76,11 +78,27 @@ If you want to keep your admin files separated you can create the same structure
           admin.css       -> File to require in Admin Rails pipeline
 ```
 
-In order to refer to `admin` namespace just add `--admin` at the end of the gulp command. For example `gulp watch --admin` or  simply `gulp --admin`.
+In order to refer to `admin` namespace just add `--admin` at the end of the gulp command. 
+
+* `gulp sass --admin`: preprocesses sass files
+* `gulp js --admin`: preprocesses js files
+* `gulp --admin`: executes `gulp sass --admin` and `gulp js --admin`
+* `gulp watch --admin`: watches stylesheet and javascript directories and executes `gulp sass --admin` and `gulp js --admin` on every file change
+* `gulp bs --admin`: runs Browsersync in background and executes `gulp sass --admin` and `gulp js --admin` on every file change
+
 
 ### Extra feature ###
 
-You might want to have third namespace for a plugin that you use only on one specific view of your app. For example a script called `myPlugin`. The only thing you have to do is create the structure for it as you have done for admin and replacing admin with `myPlugin`. Then you'll be able to execute gulp commands using appendin `--extra myPlugin` to them. For example `gulp watch --extra myPlugin` or `gulp --extra myPlugin`.
+Always wanted to `gulp watch --extra myPlugin`?
+
+You might want to have third namespace for a plugin that you use only on one specific view of your app. For example a script called `myPlugin` (it can be anything you want). The only thing you have to do is create the structure for it as you have done for admin and replacing admin with `myPlugin`. Then you'll be able to execute gulp commands using appendin `--extra myPlugin` to them. 
+
+* `gulp sass --extra myPlugin`: preprocesses sass files
+* `gulp js --extra myPlugin`: preprocesses js files
+* `gulp --extra myPlugin`: executes `gulp sass --extra myPlugin` and `gulp js --extra myPlugin`
+* `gulp watch --extra myPlugin`: watches stylesheet and javascript directories and executes `gulp sass --extra myPlugin` and `gulp js --extra myPlugin` on every file change
+* `gulp bs --extra myPlugin`: runs Browsersync in background and executes `gulp sass --extra myPlugin` and `gulp js --extra myPlugin` on every file change
+
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This gulpfile has been created to split `app` files from the `admin` ones. It ha
 
 It has been thought for Ruby on Rails 4.2.6 or later and Node 6.2.0 or later.
 
-# Required structure #
+### Required structure ###
 
 In order to work you need to have the following directory structure:
 
@@ -44,7 +44,7 @@ You can use the following commands:
 * `gulp watch`: watches stylesheet and javascript directories and executes `gulp sass` and `gulp js` on every file change
 * `gulp bs`: runs Browsersync in background and executes `gulp sass` and `gulp js` on every file change
 
-# Admin files #
+### Admin files ###
 
 If you want to keep your admin files separated you can create the same structure as before but within `admin` namespace. Refer to the following schema.
 
@@ -78,9 +78,11 @@ If you want to keep your admin files separated you can create the same structure
 
 In order to refer to `admin` namespace just add `--admin` at the end of the gulp command. For example `gulp watch --admin` or  simply `gulp --admin`.
 
-# Extra feature #
+### Extra feature ###
 
 You might want to have third namespace for a plugin that you use only on one specific view of your app. For example a script called `myPlugin`. The only thing you have to do is create the structure for it as you have done for admin and replacing admin with `myPlugin`. Then you'll be able to execute gulp commands using appendin `--extra myPlugin` to them. For example `gulp watch --extra myPlugin` or `gulp --extra myPlugin`.
 
-# NEXT FEATURES #
+----
+
+### NEXT FEATURES ###
 * Implement a command to create the structure automagically

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 ### GULPFILE ###
 
-This gulpfile has been created to split `app` files from the `admin` ones. It has also an `extra` feature that let's you create the namespace you want without modifing Gulpfile settings.
+This gulpfile preprocesses your Rails javascripts and stylesheets.
+
+The idea behind this is to split your `app` files from the `admin` ones. It has also an `extra` feature that let's you create the namespace for as many plugins as you want without modifing Gulpfile settings.
 
 It has been thought for Ruby on Rails 4.2.6 or later and Node 6.2.0 or later.
 
-* * * 
+What you can do:
+* Use gulp for your [application assets][app]
+* Use gulp for your [admin assets][admin]
+* Use gulp for your [plugin assets][extra]
 
+* * * 
+[app]
 ### Required structure ###
 
 In order to setup properly copy/paste `gulpfile.js` and `package.json` in your project's root. To install gulp dependencies run the following commands from Terminal (or any command-line):
@@ -57,7 +64,7 @@ After your directory is correctly setup you can use the following commands:
 * `gulp bs`: it runs Browsersync in background and executes `gulp sass` and `gulp js` on every file change
 
 * * *
-
+[admin]
 ### Admin files ###
 
 If you want to keep your admin files separated you can create the same structure as before but within `admin` namespace. 
@@ -107,7 +114,7 @@ In order to refer to `admin` namespace just add `--admin` at the end of the gulp
 * * *
 
 ### Extra feature ###
-
+[extra]
 Always wanted to `gulp watch --extra myPlugin`?
 
 You might want to have third namespace for a plugin that you use only on one specific view of your app. For example a script called `myPlugin` (it can be anything you want). The only thing you have to do is create the structure for it as you have done before with the setup task:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ What you can do:
 
 * * * 
 
-###[app] Required structure ###
+### [app]Required structure ###
 
 In order to setup properly copy/paste `gulpfile.js` and `package.json` in your project's root. To install gulp dependencies run the following commands from Terminal (or any command-line):
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,32 +1,35 @@
+/* "esversion: 6" */
+
 'use strict';
 
 /*
 | - - - - - - - - - - - - - - - - - - - - 
 | @ GULP File
 | @ Github: giuseppesalvo
+| @ Github: a-barbieri
 | - - - - - - - - - - - - - - - - - - - -
 */
 
 //Dependencies
-const gulp          = require('gulp' )
-    , browserify    = require('browserify')
-    , sass          = require('gulp-sass' )
-    , autoprefixer  = require('gulp-autoprefixer' )
-    , gp_notify     = require("gulp-notify" )
-    , gutil         = require('gulp-util' )
-    , browserSync   = require('browser-sync').create()
-    , fs            = require('fs')
-    , uglify        = require('gulp-uglify')
-    , argv          = require('yargs').argv
-
+const gulp            = require('gulp' ), 
+        browserify    = require('browserify'), 
+        sass          = require('gulp-sass' ), 
+        autoprefixer  = require('gulp-autoprefixer' ), 
+        gp_notify     = require("gulp-notify" ), 
+        gutil         = require('gulp-util' ), 
+        browserSync   = require('browser-sync').create(), 
+        fs            = require('fs'), 
+        uglify        = require('gulp-uglify'), 
+        argv          = require('yargs').argv,
+        expect        = require('gulp-expect-file');
 
 /**
  * Utils
  */
-const errorLog = err  => gp_notify({ message: err, sound: true, onLast: false } ).write( err );
-const notify   = msg  => gp_notify({ message: msg, onLast: true } );
-const log      = msg  => gutil.log( gutil.colors.blue( msg ) );
-const assets   = path => './app/assets' + path ;
+const errorLog = (err)  => gp_notify( { message: err, sound: true, onLast: false } ).write( err );
+const notify   = (msg)  => gp_notify( { message: msg, onLast: true } );
+const log      = (msg)  => gutil.log( gutil.colors.blue( msg ) );
+const assets   = (path) => 'app/assets' + path ;
 
 /**
  * Big class
@@ -34,16 +37,31 @@ const assets   = path => './app/assets' + path ;
 
 class Gulp {
 
-    constructor({ paths, check, dests, proxy = "http://localhost:3000" }) {
+    constructor( proxy = "http://localhost:3000" ) {
 
+        if ( argv.admin )
+            var NS = "admin";
+        else if ( argv.extra )
+            var NS = argv.extra
+        else
+            var NS = "app";
+
+        this.paths = { sass: {}, js: {} }
+        this.check = { sass: {}, js: {}, browserify: {} }
+        this.dests = { sass: {}, js: {} } 
+
+        this.paths.sass[ NS ]       = assets(`/stylesheets/${NS}/${NS}.scss`);
+        this.paths.js[ NS ]         = assets(`/javascripts/${NS}/${NS}.js`);
+        this.check.sass[ NS ]       = assets(`/stylesheets/${NS}/**/*.scss`);
+        this.check.js[ NS ]         = assets(`/javascripts/${NS}/**/*.js`);
+        this.check.browserify[ NS ] = assets(`/javascripts/${NS}/**/*.js`);
+        this.dests.sass[ NS ]       = assets('/stylesheets/dist');
+        this.dests.js[ NS ]         = assets(`/javascripts/dist/${NS}.bundle.js`);
+
+        this.namespace = NS;
         this.proxy = proxy;
-        this.paths = paths;
-        this.check = check;
-        this.dests = dests;
 
-        this.namespace = argv.admin ? "admin" : "app" ;
-
-        this.tasks();    
+        this.tasks();
     }
 
     tasks() {
@@ -65,23 +83,26 @@ class Gulp {
         const prefix_conf = {
             browsers : ['> 1%', 'IE 7'],
             cascade  : false
-        }
+        };
 
         gulp.src( this.paths.sass[this.namespace] )
+            .pipe( expect( { errorOnFailure: true }, this.paths.sass[this.namespace] ).on( 'error', errorLog ) )
             .pipe( sass().on( 'error', errorLog ) )
             .pipe( autoprefixer(prefix_conf) )
             .pipe( gulp.dest( this.dests.sass[this.namespace] ) )
             .pipe( browserSync.stream() )
             .pipe( notify( "Sass compiled" ) )
-
+            .pipe( notify( function(file) {
+                return "Some file: " + file.relative;
+            }));
     }
 
     js() {
 
-        const extensions = [ ".js", ".jsx", ".vertex", ".fragment" ]
-            , paths      = [ './node_modules', this.check.browserify[this.namespace] ]
-            , presets    = [ "es2015", "react" ]
-            , stringExt  = [ ".vertex", ".fragment" ]
+        const extensions = [ ".js", ".jsx", ".vertex", ".fragment" ], 
+                paths      = [ './node_modules', this.check.browserify[this.namespace] ], 
+                presets    = [ "es2015", "react" ], 
+                stringExt  = [ ".vertex", ".fragment" ];
 
         const br = browserify( this.paths.js[this.namespace], { extensions, paths });
 
@@ -91,27 +112,28 @@ class Gulp {
           .on( 'error', errorLog )
           .pipe( notify( "Scripts compiled" ) )
           .pipe( browserSync.stream() )
-          .pipe( fs.createWriteStream( this.dests.js[this.namespace] ) )
+          .pipe( fs.createWriteStream( this.dests.js[this.namespace] ) );
     }
     
     uglify() {
 
         let dest = this.dests.js[this.namespace].split('/');
             dest.splice(-1,1);
-            dest = dest.join('/')
+            dest = dest.join('/');
     
         gulp.src( this.dests.js[this.namespace] )
             .pipe( uglify() )
             .pipe( gulp.dest( dest + "/min" ) )
-            .pipe( notify('uglify') )
+            .pipe( notify('uglify') );
     }
 
     browserSync( settings = {} ) {
         settings.proxy = this.proxy;
-        browserSync.init( settings )
+        browserSync.init( settings );
     }
 
     watch() {
+
         gulp.watch( this.check.sass[this.namespace] , ['sass']).on( 'change', browserSync.reload );
         gulp.watch( this.check.js[this.namespace]   , ['js'  ]).on( 'change', browserSync.reload );
     }
@@ -120,43 +142,5 @@ class Gulp {
 /**
  * Init
  */
-new Gulp({
 
-    paths: {
-        sass : {
-            app   : assets('/stylesheets/app/app.scss'),
-            admin : assets('/stylesheets/admin/admin.scss'),
-        },
-        js : {
-            app   : assets('/javascripts/app/app.js'),
-            admin : assets('/javascripts/admin/admin.js')
-        }
-    },
-
-    // avoid dests watch
-    check : {
-        sass : {
-            app   : assets('/stylesheets/app/**/*.scss'),
-            admin : assets('/stylesheets/admin/**/*.scss'),
-        },
-        js : {
-            app   : assets('/javascripts/app/**/*.js'),
-            admin : assets('/javascripts/admin/**/*.js'),
-        },
-        browserify : {
-            app   : assets('/javascripts/app/**/*.js'),
-            admin : assets('/javascripts/admin/**/*.js')
-        }
-    },
-    
-    dests : {
-        sass: {
-            app   : assets('/stylesheets/dist'),
-            admin : assets('/stylesheets/dist'),
-        },
-        js: {
-            app   : assets('/javascripts/dist/app.bundle.js'),
-            admin : assets('/javascripts/dist/admin.bundle.js')
-        }
-    }
-})
+new Gulp();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,9 +91,8 @@ class Gulp {
             .pipe( autoprefixer(prefix_conf) )
             .pipe( gulp.dest( this.dests.sass[this.namespace] ) )
             .pipe( browserSync.stream() )
-            .pipe( notify( "Sass compiled" ) )
             .pipe( notify( function(file) {
-                return "Some file: " + file.relative;
+                return "Sass compiled: " + file.relative;
             }));
     }
 
@@ -107,12 +106,14 @@ class Gulp {
         const br = browserify( this.paths.js[this.namespace], { extensions, paths });
 
         br.transform("babelify", { presets })
-          .transform("stringify", { appliesTo: { includeExtensions: stringExt } })
-          .bundle()
-          .on( 'error', errorLog )
-          .pipe( notify( "Scripts compiled" ) )
-          .pipe( browserSync.stream() )
-          .pipe( fs.createWriteStream( this.dests.js[this.namespace] ) );
+            .transform("stringify", { appliesTo: { includeExtensions: stringExt } })
+            .bundle()
+            .on( 'error', errorLog )
+            .pipe( notify( function(file) {
+                return "Sass compiled: " + file.relative;
+            }))
+            .pipe( browserSync.stream() )
+            .pipe( fs.createWriteStream( this.dests.js[this.namespace] ) );
     }
     
     uglify() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,9 +109,7 @@ class Gulp {
             .transform("stringify", { appliesTo: { includeExtensions: stringExt } })
             .bundle()
             .on( 'error', errorLog )
-            .pipe( notify( function(file) {
-                return "Sass compiled: " + file.relative;
-            }))
+            .pipe( notify("Js compiled"))
             .pipe( browserSync.stream() )
             .pipe( fs.createWriteStream( this.dests.js[this.namespace] ) );
     }

--- a/package.json
+++ b/package.json
@@ -1,23 +1,32 @@
 {
-  "name": "gulpfile",
+  "name": "testing",
   "version": "1.0.0",
-  "description": "gulpfile",
-  "main": "gulpfile.js",
+  "description": "Testing package",
+  "main": "index.php",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "devDependencies": {
+    "babelify": "^7.2.0",
+    "browser-sync": "^2.7.13",
+    "gulp": "^3.9.0",
+    "gulp-autoprefixer": "^2.3.1",
+    "gulp-expect-file": "0.0.7",
+    "gulp-notify": "^2.2.0",
+    "gulp-util": "^3.0.5",
+    "yargs": "^4.7.1"
+  },
   "dependencies": {
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
-    "babelify": "^7.2.0",
+    "babelify": "^7.3.0",
     "browser-sync": "^2.12.8",
     "browserify": "^13.0.1",
     "gulp": "^3.9.1",
-    "gulp-autoprefixer": "^2.3.1",
-    "gulp-notify": "^2.2.0",
     "gulp-sass": "^2.3.1",
     "gulp-uglify": "^1.5.3",
-    "gulp-util": "^3.0.5",
     "node-sass": "^3.7.0",
-    "stringify": "^5.1.0",
-    "yargs": "^4.7.1"
+    "stringify": "^5.1.0"
   },
   "author": "Giuseppe Salvo",
   "license": "ISC"


### PR DESCRIPTION
I path ora sono creati dinamicamente.

Ho aggiunto la possibilità di eseguire gulp non solo su `admin`, ma su qualsiasi namespace. Tipo se hai un script `coverAnimation.js` puoi creare tutto il suo ambiente e preprocessarlo eseguendo:
```
gulp --extra coverAnimation
```
Figo, no? 

Utile se hai file che sono al di fuori delle normali pipeline di Rails. Ad esempio 
```
<%= javascript_include_tag 'coverAnimation' %>
```